### PR TITLE
Loosen graphql version constraint

### DIFF
--- a/dry-graphql.gemspec
+++ b/dry-graphql.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.add_runtime_dependency 'dry-struct', '>= 0.4.0'
   spec.add_runtime_dependency 'dry-types', '< 0.15.0'
-  spec.add_runtime_dependency 'graphql', '~> 1.8.0'
+  spec.add_runtime_dependency 'graphql', '~> 1.8'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler', '~> 1.16'


### PR DESCRIPTION
This PR makes it possible to use GraphQL 1.8.x and 1.9.x.